### PR TITLE
Added distance indicator to Biome Compass

### DIFF
--- a/src/main/java/dev/rusthero/biomecompass/listeners/MenuClickListener.java
+++ b/src/main/java/dev/rusthero/biomecompass/listeners/MenuClickListener.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static net.md_5.bungee.api.ChatMessageType.ACTION_BAR;
 import static org.bukkit.Sound.BLOCK_CONDUIT_ACTIVATE;
 import static org.bukkit.Sound.BLOCK_CONDUIT_AMBIENT;
@@ -96,7 +97,9 @@ public class MenuClickListener implements Listener {
                     return;
                 }
 
-                player.spigot().sendMessage(ACTION_BAR, new TextComponent("§aLocated"));
+                int distance = (int) Math.round(player.getLocation().distance(location.get()));
+                String locatedMessage = format("§aLocated (%d blocks away)", distance);
+                player.spigot().sendMessage(ACTION_BAR, new TextComponent(locatedMessage));
                 player.playSound(player.getLocation(), BLOCK_CONDUIT_ACTIVATE, 1.0f, 1.0f);
 
                 String biomeName = element.get().displayName;

--- a/src/main/java/dev/rusthero/biomecompass/listeners/MenuClickListener.java
+++ b/src/main/java/dev/rusthero/biomecompass/listeners/MenuClickListener.java
@@ -97,8 +97,12 @@ public class MenuClickListener implements Listener {
                     return;
                 }
 
-                int distance = (int) Math.round(player.getLocation().distance(location.get()));
-                String locatedMessage = format("§aLocated (%d blocks away)", distance);
+                String locatedMessage = "§aLocated";
+                // If player teleports to another dimension while locating, we cannot calculate distance.
+                if (player.getWorld().equals(location.get().getWorld())) {
+                    int distance = (int) Math.round(player.getLocation().distance(location.get()));
+                    locatedMessage += format(" (§e%d blocks away§a)", distance);
+                }
                 player.spigot().sendMessage(ACTION_BAR, new TextComponent(locatedMessage));
                 player.playSound(player.getLocation(), BLOCK_CONDUIT_ACTIVATE, 1.0f, 1.0f);
 


### PR DESCRIPTION
This pull request adds a new feature to the Biome Compass plugin: a distance indicator that shows the distance to the selected biome in blocks. This feature can be useful for players who want to know how far they are from their destination, and can be especially helpful when navigating to biomes that are far away or hard to find.

This feature does not work when player teleports to another dimension while locating. 