### PR TITLE
Added version tracker

### DIFF
--- a/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
+++ b/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
@@ -54,15 +54,16 @@ public class BiomeCompass extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        // Check if the plugin is outdated and log a warning message if not.
+        // Check if the plugin is outdated and log a warning message if it is.
         try {
             VersionTracker versionTracker = new VersionTracker(this);
-            if (!versionTracker.isUpToDate())
-                getLogger().warning(format("I am outdated! The latest version is %s, Please update to ensure " +
-                                                   "compatibility and access to new features",
-                                           versionTracker.latestVersion));
-        } catch (IOException e) {
-            getLogger().warning("Could not check for the latest version.");
+            if (!versionTracker.isUpToDate()) {
+                String outdatedMessage = "I am outdated! The latest version is %s." +
+                        "Please update to ensure compatibility and access to new features";
+                getLogger().warning(format(outdatedMessage, versionTracker.latestVersion));
+            }
+        } catch (IOException ignored) {
+            getLogger().warning("Version tracker could not check for the latest version");
         }
 
         // Prepare the configuration and settings for easier access to constants.

--- a/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
+++ b/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
@@ -13,6 +13,10 @@ import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.IOException;
+
+import static java.lang.String.format;
+
 /**
  * This class represents the BiomeCompass plugin. It prepares the configuration, settings, cache for locate queries,
  * biome locators, biomes menu, listeners, and craft recipe.
@@ -50,6 +54,17 @@ public class BiomeCompass extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        // Check if the plugin is outdated and log a warning message if not.
+        try {
+            VersionTracker versionTracker = new VersionTracker(this);
+            if (!versionTracker.isUpToDate())
+                getLogger().warning(format("I am outdated! The latest version is %s, Please update to ensure " +
+                                                   "compatibility and access to new features",
+                                           versionTracker.latestVersion));
+        } catch (IOException e) {
+            getLogger().warning("Could not check for the latest version.");
+        }
+
         // Prepare the configuration and settings for easier access to constants.
         getConfig().options().copyDefaults(true);
         saveDefaultConfig();

--- a/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
+++ b/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
@@ -17,8 +17,9 @@ public class VersionTracker {
     static {
         try {
             API_URL = new URL("https://api.github.com/repos/rusthero/BiomeCompass/releases/latest");
-        } catch (MalformedURLException e) {
-            throw new RuntimeException(e);
+        } catch (MalformedURLException exception) {
+            // This should never throw.
+            throw new RuntimeException(exception);
         }
     }
 
@@ -30,21 +31,11 @@ public class VersionTracker {
         currentVersion = "v" + descriptionFile.getVersion();
 
         HttpURLConnection connection = (HttpURLConnection) API_URL.openConnection();
-        int responseCode = connection.getResponseCode();
-        // TODO Remove these debug lines
-        plugin.getLogger().info("\nSending 'GET' request to URL : " + API_URL);
-        plugin.getLogger().info("Response Code : " + responseCode);
 
         BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
-        /*String inputLine;
-        StringBuffer response = new StringBuffer();
-        while ((inputLine = reader.readLine()) != null) response.append(inputLine);
-        reader.close();
-        plugin.getLogger().info(response.toString());*/
-
         JsonElement json = new JsonParser().parse(reader);
+
         latestVersion = json.getAsJsonObject().get("tag_name").getAsString();
-        plugin.getLogger().info("Latest version is " + latestVersion);
     }
 
     public boolean isUpToDate() {

--- a/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
+++ b/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
@@ -1,0 +1,53 @@
+package dev.rusthero.biomecompass;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.bukkit.plugin.PluginDescriptionFile;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class VersionTracker {
+    private static final URL API_URL;
+
+    static {
+        try {
+            API_URL = new URL("https://api.github.com/repos/rusthero/BiomeCompass/releases/latest");
+        } catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public final String currentVersion;
+    public final String latestVersion;
+
+    public VersionTracker(BiomeCompass plugin) throws IOException {
+        PluginDescriptionFile descriptionFile = plugin.getDescription();
+        currentVersion = "v" + descriptionFile.getVersion();
+
+        HttpURLConnection connection = (HttpURLConnection) API_URL.openConnection();
+        int responseCode = connection.getResponseCode();
+        // TODO Remove these debug lines
+        plugin.getLogger().info("\nSending 'GET' request to URL : " + API_URL);
+        plugin.getLogger().info("Response Code : " + responseCode);
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        /*String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = reader.readLine()) != null) response.append(inputLine);
+        reader.close();
+        plugin.getLogger().info(response.toString());*/
+
+        JsonElement json = new JsonParser().parse(reader);
+        latestVersion = json.getAsJsonObject().get("tag_name").getAsString();
+        plugin.getLogger().info("Latest version is " + latestVersion);
+    }
+
+    public boolean isUpToDate() {
+        return currentVersion.equals(latestVersion);
+    }
+}


### PR DESCRIPTION
The version tracker is a simple utility that checks for new versions of the plugin on startup, and displays a notification in the server console if a newer version is available. This can be useful for server administrators who want to keep their plugin up-to-date, and can help ensure that the plugin is always running the latest and most stable version.