### PR TITLE
Added option to disable biomes on menu from configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 }
 
 processResources {
-    filesMatching("**/plugin.yml") {
+    filesMatching("**/*.yml") {
         expand(project.properties)
     }
 }

--- a/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
+++ b/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
@@ -60,7 +60,7 @@ public class BiomeCompass extends JavaPlugin {
         // Create the player biome locators registry to track player cooldowns and active queries.
         playerBiomeLocators = new PlayerBiomeLocatorRegistry();
         // Create the biomes menu, which will be used by players to select a biome and initiate a search.
-        biomesMenu = new BiomesMenu();
+        biomesMenu = new BiomesMenu(settings.biomes);
 
         // Register the listeners required for the plugin to function properly.
         PluginManager pluginManager = getServer().getPluginManager();

--- a/src/main/java/dev/rusthero/biomecompass/BiomeElement.java
+++ b/src/main/java/dev/rusthero/biomecompass/BiomeElement.java
@@ -90,10 +90,9 @@ public enum BiomeElement {
     SMALL_END_ISLANDS(Environment.THE_END, false, "END_STONE", DARK_PURPLE),
     END_MIDLANDS(Environment.THE_END, false, "END_STONE", DARK_PURPLE),
     END_HIGHLANDS(Environment.THE_END, false, "CHORUS_PLANT", DARK_PURPLE),
-    END_BARRENS(Environment.THE_END, false, "END_STONE", DARK_PURPLE);
+    END_BARRENS(Environment.THE_END, false, "END_STONE", DARK_PURPLE),
 
-    // https://minecraft.fandom.com/wiki/The_Void - Not useful for normal dimensions so commented.
-    // THE_VOID(Environment.NORMAL, false, "STONE", BLACK);
+    THE_VOID(Environment.NORMAL, false, "STONE", BLACK);
 
     /**
      * Returns the BiomeElement associated with the given ItemStack, if one exists.

--- a/src/main/java/dev/rusthero/biomecompass/Settings.java
+++ b/src/main/java/dev/rusthero/biomecompass/Settings.java
@@ -1,6 +1,10 @@
 package dev.rusthero.biomecompass;
 
+import org.bukkit.block.Biome;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.HashMap;
 
 /**
  * This class represents the settings read from the configuration file of the plugin.
@@ -37,6 +41,8 @@ public final class Settings {
      */
     public final int cacheSize;
 
+    public final HashMap<Biome, Boolean> biomes;
+
     /**
      * Constructs a new Settings instance and reads in the setting values from the specified configuration file.
      *
@@ -47,5 +53,16 @@ public final class Settings {
         this.resolution = config.getInt("resolution");
         this.radius = config.getInt("radius");
         this.cacheSize = config.getInt("cache_size");
+
+        biomes = new HashMap<>();
+        ConfigurationSection section = config.getConfigurationSection("biomes");
+        if (section != null)
+            section.getKeys(true).forEach(biomeStr -> {
+                try {
+                    biomes.put(Biome.valueOf(biomeStr.toUpperCase()), section.getBoolean(biomeStr));
+                } catch (IllegalArgumentException ignored) {
+
+                }
+            });
     }
 }

--- a/src/main/java/dev/rusthero/biomecompass/gui/BiomesMenu.java
+++ b/src/main/java/dev/rusthero/biomecompass/gui/BiomesMenu.java
@@ -1,13 +1,15 @@
 package dev.rusthero.biomecompass.gui;
 
 import dev.rusthero.biomecompass.BiomeElement;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.block.Biome;
-import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 
 import java.util.HashMap;
 
+import static net.md_5.bungee.api.ChatMessageType.ACTION_BAR;
 import static org.bukkit.World.Environment;
 
 /**
@@ -27,7 +29,7 @@ public class BiomesMenu {
      * This constructor creates three inventories for selecting biomes in different dimensions. It also adds every
      * BiomeElement to their corresponding inventories according to their dimensions.
      */
-    public BiomesMenu() {
+    public BiomesMenu(HashMap<Biome, Boolean> biomes) {
         inventories = new HashMap<>();
 
         Inventory overworld = Bukkit.createInventory(null, 54, "§2§l[§1§lOVERWORLD§2§l] §9Select a biome");
@@ -42,6 +44,9 @@ public class BiomesMenu {
         // Add every BiomeElement to their corresponding inventories based on their dimensions.
         for (Biome biome : Biome.values())
             try {
+                // Skip biomes which are set false in configuration
+                if (biomes.get(biome) != null && !biomes.get(biome)) continue;
+
                 BiomeElement element = BiomeElement.valueOf(biome.name());
                 Inventory inventory = inventories.get(element.environment);
                 inventory.addItem(element.item);
@@ -57,10 +62,15 @@ public class BiomesMenu {
      *
      * @param player The player who will open the menu.
      */
-    public void open(HumanEntity player) {
+    public void open(Player player) {
         Environment environment = player.getWorld().getEnvironment();
-        Inventory page = inventories.get(environment);
-        player.openInventory(page);
+        Inventory inventory = inventories.get(environment);
+
+        // If no biomes are added to the inventory, no need to show an empty menu
+        if (inventory.firstEmpty() == 0)
+            player.spigot().sendMessage(ACTION_BAR, new TextComponent("§cNot allowed in this dimension"));
+        else
+            player.openInventory(inventory);
     }
 
     /**

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-# Biome Compass Configuration File
+# Biome Compass v${version} Configuration File
 # Check wiki to learn more https://github.com/rusthero/BiomeCompass/wiki
 
 cooldown: 5
@@ -6,3 +6,67 @@ resolution: 32
 radius: 6400
 cache_size: 100
 
+biomes:
+  ocean: true
+  plains: true
+  desert: true
+  windswept_hills: true
+  forest: true
+  taiga: true
+  swamp: true
+  mangrove_swamp: true
+  river: true
+  frozen_ocean: true
+  frozen_river: true
+  snowy_plains: true
+  mushroom_fields: true
+  beach: true
+  jungle: true
+  sparse_jungle: true
+  deep_ocean: true
+  stony_shore: true
+  snowy_beach: true
+  birch_forest: true
+  dark_forest: true
+  snowy_taiga: true
+  old_growth_pine_taiga: true
+  windswept_forest: true
+  savanna: true
+  savanna_plateau: true
+  badlands: true
+  wooded_badlands: true
+  warm_ocean: true
+  lukewarm_ocean: true
+  cold_ocean: true
+  deep_lukewarm_ocean: true
+  deep_cold_ocean: true
+  deep_frozen_ocean: true
+  sunflower_plains: true
+  windswept_gravelly_hills: true
+  flower_forest: true
+  ice_spikes: true
+  old_growth_birch_forest: true
+  old_growth_spruce_taiga: true
+  windswept_savanna: true
+  eroded_badlands: true
+  bamboo_jungle: true
+  meadow: true
+  grove: true
+  snowy_slopes: true
+  frozen_peaks: true
+  jagged_peaks: true
+  stony_peaks: true
+  dripstone_caves: true
+  lush_caves: true
+  deep_dark: true
+  nether_wastes: true
+  soul_sand_valley: true
+  crimson_forest: true
+  warped_forest: true
+  basalt_deltas: true
+  the_end: true
+  small_end_islands: true
+  end_midlands: true
+  end_highlands: true
+  end_barrens: true
+  the_void: false


### PR DESCRIPTION
This pull request adds an option to disable certain biomes from the Biome Compass plugin's configuration. This allows players to customize the compass to only show certain biomes, making it easier to navigate to the biomes they want to find. This feature can be useful for servers that want to limit the biomes that players can find with the compass, or for players who only want to see certain biomes in the compass GUI.