### PR TITLE
Add distance indicator and version tracker to Biome Compass

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ dependencies {
 }
 
 processResources {
-    filesMatching("**/plugin.yml") {
+    filesMatching("**/*.yml") {
         expand(project.properties)
     }
 }

--- a/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
+++ b/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
@@ -76,7 +76,7 @@ public class BiomeCompass extends JavaPlugin {
         // Create the player biome locators registry to track player cooldowns and active queries.
         playerBiomeLocators = new PlayerBiomeLocatorRegistry();
         // Create the biomes menu, which will be used by players to select a biome and initiate a search.
-        biomesMenu = new BiomesMenu();
+        biomesMenu = new BiomesMenu(settings.biomes);
 
         // Register the listeners required for the plugin to function properly.
         PluginManager pluginManager = getServer().getPluginManager();

--- a/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
+++ b/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
@@ -13,6 +13,10 @@ import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
+import java.io.IOException;
+
+import static java.lang.String.format;
+
 /**
  * This class represents the BiomeCompass plugin. It prepares the configuration, settings, cache for locate queries,
  * biome locators, biomes menu, listeners, and craft recipe.
@@ -50,6 +54,18 @@ public class BiomeCompass extends JavaPlugin {
 
     @Override
     public void onEnable() {
+        // Check if the plugin is outdated and log a warning message if it is.
+        try {
+            VersionTracker versionTracker = new VersionTracker(this);
+            if (!versionTracker.isUpToDate()) {
+                String outdatedMessage = "I am outdated! The latest version is %s." +
+                        "Please update to ensure compatibility and access to new features";
+                getLogger().warning(format(outdatedMessage, versionTracker.latestVersion));
+            }
+        } catch (IOException ignored) {
+            getLogger().warning("Version tracker could not check for the latest version");
+        }
+
         // Prepare the configuration and settings for easier access to constants.
         getConfig().options().copyDefaults(true);
         saveDefaultConfig();

--- a/src/main/java/dev/rusthero/biomecompass/BiomeElement.java
+++ b/src/main/java/dev/rusthero/biomecompass/BiomeElement.java
@@ -90,10 +90,9 @@ public enum BiomeElement {
     SMALL_END_ISLANDS(Environment.THE_END, false, "END_STONE", DARK_PURPLE),
     END_MIDLANDS(Environment.THE_END, false, "END_STONE", DARK_PURPLE),
     END_HIGHLANDS(Environment.THE_END, false, "CHORUS_PLANT", DARK_PURPLE),
-    END_BARRENS(Environment.THE_END, false, "END_STONE", DARK_PURPLE);
+    END_BARRENS(Environment.THE_END, false, "END_STONE", DARK_PURPLE),
 
-    // https://minecraft.fandom.com/wiki/The_Void - Not useful for normal dimensions so commented.
-    // THE_VOID(Environment.NORMAL, false, "STONE", BLACK);
+    THE_VOID(Environment.NORMAL, false, "STONE", BLACK);
 
     /**
      * Returns the BiomeElement associated with the given ItemStack, if one exists.

--- a/src/main/java/dev/rusthero/biomecompass/Settings.java
+++ b/src/main/java/dev/rusthero/biomecompass/Settings.java
@@ -41,6 +41,9 @@ public final class Settings {
      */
     public final int cacheSize;
 
+    /**
+     * Determines which biomes are displayed in the Biome Compass GUI.
+     */
     public final HashMap<Biome, Boolean> biomes;
 
     /**

--- a/src/main/java/dev/rusthero/biomecompass/Settings.java
+++ b/src/main/java/dev/rusthero/biomecompass/Settings.java
@@ -1,6 +1,10 @@
 package dev.rusthero.biomecompass;
 
+import org.bukkit.block.Biome;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.HashMap;
 
 /**
  * This class represents the settings read from the configuration file of the plugin.
@@ -37,6 +41,8 @@ public final class Settings {
      */
     public final int cacheSize;
 
+    public final HashMap<Biome, Boolean> biomes;
+
     /**
      * Constructs a new Settings instance and reads in the setting values from the specified configuration file.
      *
@@ -47,5 +53,16 @@ public final class Settings {
         this.resolution = config.getInt("resolution");
         this.radius = config.getInt("radius");
         this.cacheSize = config.getInt("cache_size");
+
+        biomes = new HashMap<>();
+        ConfigurationSection section = config.getConfigurationSection("biomes");
+        if (section != null)
+            section.getKeys(true).forEach(biomeStr -> {
+                try {
+                    biomes.put(Biome.valueOf(biomeStr.toUpperCase()), section.getBoolean(biomeStr));
+                } catch (IllegalArgumentException ignored) {
+
+                }
+            });
     }
 }

--- a/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
+++ b/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
@@ -1,0 +1,44 @@
+package dev.rusthero.biomecompass;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.bukkit.plugin.PluginDescriptionFile;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class VersionTracker {
+    private static final URL API_URL;
+
+    static {
+        try {
+            API_URL = new URL("https://api.github.com/repos/rusthero/BiomeCompass/releases/latest");
+        } catch (MalformedURLException exception) {
+            // This should never throw.
+            throw new RuntimeException(exception);
+        }
+    }
+
+    public final String currentVersion;
+    public final String latestVersion;
+
+    public VersionTracker(BiomeCompass plugin) throws IOException {
+        PluginDescriptionFile descriptionFile = plugin.getDescription();
+        currentVersion = "v" + descriptionFile.getVersion();
+
+        HttpURLConnection connection = (HttpURLConnection) API_URL.openConnection();
+
+        BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
+        JsonElement json = new JsonParser().parse(reader);
+
+        latestVersion = json.getAsJsonObject().get("tag_name").getAsString();
+    }
+
+    public boolean isUpToDate() {
+        return currentVersion.equals(latestVersion);
+    }
+}

--- a/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
+++ b/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
@@ -11,26 +11,42 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+/**
+ * a utility class for the Biome Compass plugin that allows the plugin to check for updates from the plugin's GitHub
+ * repository.
+ */
 public class VersionTracker {
-    private static final URL API_URL;
+    /**
+     * URL of the GitHub API endpoint for the plugin's releases. This field is used to retrieve the latest version of
+     * the plugin when the {@link VersionTracker} object is constructed.
+     */
+    private static final URL ENDPOINT_URL;
 
     static {
         try {
-            API_URL = new URL("https://api.github.com/repos/rusthero/BiomeCompass/releases/latest");
+            ENDPOINT_URL = new URL("https://api.github.com/repos/rusthero/BiomeCompass/releases/latest");
         } catch (MalformedURLException exception) {
             // This should never throw.
             throw new RuntimeException(exception);
         }
     }
 
+    /**
+     * Current version of the plugin, as specified in the plugin's plugin.yml file.
+     */
     public final String currentVersion;
+
+    /**
+     * latest version of the plugin, as retrieved from the GitHub API.
+     */
     public final String latestVersion;
 
     public VersionTracker(BiomeCompass plugin) throws IOException {
         PluginDescriptionFile descriptionFile = plugin.getDescription();
+        // We use the prefix "v" in release tag names.
         currentVersion = "v" + descriptionFile.getVersion();
 
-        HttpURLConnection connection = (HttpURLConnection) API_URL.openConnection();
+        HttpURLConnection connection = (HttpURLConnection) ENDPOINT_URL.openConnection();
 
         BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
         JsonElement json = new JsonParser().parse(reader);
@@ -38,6 +54,12 @@ public class VersionTracker {
         latestVersion = json.getAsJsonObject().get("tag_name").getAsString();
     }
 
+    /**
+     * Checks if the plugin is up-to-date.
+     *
+     * @return {@code true} if the current version of the plugin is the same as the latest version, and {@code false}
+     * otherwise.
+     */
     public boolean isUpToDate() {
         return currentVersion.equals(latestVersion);
     }

--- a/src/main/java/dev/rusthero/biomecompass/gui/BiomesMenu.java
+++ b/src/main/java/dev/rusthero/biomecompass/gui/BiomesMenu.java
@@ -1,13 +1,15 @@
 package dev.rusthero.biomecompass.gui;
 
 import dev.rusthero.biomecompass.BiomeElement;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.Bukkit;
 import org.bukkit.block.Biome;
-import org.bukkit.entity.HumanEntity;
+import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 
 import java.util.HashMap;
 
+import static net.md_5.bungee.api.ChatMessageType.ACTION_BAR;
 import static org.bukkit.World.Environment;
 
 /**
@@ -27,7 +29,7 @@ public class BiomesMenu {
      * This constructor creates three inventories for selecting biomes in different dimensions. It also adds every
      * BiomeElement to their corresponding inventories according to their dimensions.
      */
-    public BiomesMenu() {
+    public BiomesMenu(HashMap<Biome, Boolean> biomes) {
         inventories = new HashMap<>();
 
         Inventory overworld = Bukkit.createInventory(null, 54, "§2§l[§1§lOVERWORLD§2§l] §9Select a biome");
@@ -42,6 +44,9 @@ public class BiomesMenu {
         // Add every BiomeElement to their corresponding inventories based on their dimensions.
         for (Biome biome : Biome.values())
             try {
+                // Skip biomes which are set false in configuration
+                if (biomes.get(biome) != null && !biomes.get(biome)) continue;
+
                 BiomeElement element = BiomeElement.valueOf(biome.name());
                 Inventory inventory = inventories.get(element.environment);
                 inventory.addItem(element.item);
@@ -57,10 +62,15 @@ public class BiomesMenu {
      *
      * @param player The player who will open the menu.
      */
-    public void open(HumanEntity player) {
+    public void open(Player player) {
         Environment environment = player.getWorld().getEnvironment();
-        Inventory page = inventories.get(environment);
-        player.openInventory(page);
+        Inventory inventory = inventories.get(environment);
+
+        // If no biomes are added to the inventory, no need to show an empty menu
+        if (inventory.firstEmpty() == 0)
+            player.spigot().sendMessage(ACTION_BAR, new TextComponent("§cNot allowed in this dimension"));
+        else
+            player.openInventory(inventory);
     }
 
     /**

--- a/src/main/java/dev/rusthero/biomecompass/listeners/MenuClickListener.java
+++ b/src/main/java/dev/rusthero/biomecompass/listeners/MenuClickListener.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.ItemStack;
 
 import java.util.Optional;
 
+import static java.lang.String.format;
 import static net.md_5.bungee.api.ChatMessageType.ACTION_BAR;
 import static org.bukkit.Sound.BLOCK_CONDUIT_ACTIVATE;
 import static org.bukkit.Sound.BLOCK_CONDUIT_AMBIENT;
@@ -96,7 +97,13 @@ public class MenuClickListener implements Listener {
                     return;
                 }
 
-                player.spigot().sendMessage(ACTION_BAR, new TextComponent("§aLocated"));
+                String locatedMessage = "§aLocated";
+                // If player teleports to another dimension while locating, we cannot calculate distance.
+                if (player.getWorld().equals(location.get().getWorld())) {
+                    int distance = (int) Math.round(player.getLocation().distance(location.get()));
+                    locatedMessage += format(" (§e%d blocks away§a)", distance);
+                }
+                player.spigot().sendMessage(ACTION_BAR, new TextComponent(locatedMessage));
                 player.playSound(player.getLocation(), BLOCK_CONDUIT_ACTIVATE, 1.0f, 1.0f);
 
                 String biomeName = element.get().displayName;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-# Biome Compass Configuration File
+# Biome Compass v${version} Configuration File
 # Check wiki to learn more https://github.com/rusthero/BiomeCompass/wiki
 
 cooldown: 5
@@ -6,3 +6,67 @@ resolution: 32
 radius: 6400
 cache_size: 100
 
+biomes:
+  ocean: true
+  plains: true
+  desert: true
+  windswept_hills: true
+  forest: true
+  taiga: true
+  swamp: true
+  mangrove_swamp: true
+  river: true
+  frozen_ocean: true
+  frozen_river: true
+  snowy_plains: true
+  mushroom_fields: true
+  beach: true
+  jungle: true
+  sparse_jungle: true
+  deep_ocean: true
+  stony_shore: true
+  snowy_beach: true
+  birch_forest: true
+  dark_forest: true
+  snowy_taiga: true
+  old_growth_pine_taiga: true
+  windswept_forest: true
+  savanna: true
+  savanna_plateau: true
+  badlands: true
+  wooded_badlands: true
+  warm_ocean: true
+  lukewarm_ocean: true
+  cold_ocean: true
+  deep_lukewarm_ocean: true
+  deep_cold_ocean: true
+  deep_frozen_ocean: true
+  sunflower_plains: true
+  windswept_gravelly_hills: true
+  flower_forest: true
+  ice_spikes: true
+  old_growth_birch_forest: true
+  old_growth_spruce_taiga: true
+  windswept_savanna: true
+  eroded_badlands: true
+  bamboo_jungle: true
+  meadow: true
+  grove: true
+  snowy_slopes: true
+  frozen_peaks: true
+  jagged_peaks: true
+  stony_peaks: true
+  dripstone_caves: true
+  lush_caves: true
+  deep_dark: true
+  nether_wastes: true
+  soul_sand_valley: true
+  crimson_forest: true
+  warped_forest: true
+  basalt_deltas: true
+  the_end: true
+  small_end_islands: true
+  end_midlands: true
+  end_highlands: true
+  end_barrens: true
+  the_void: false

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: BiomeCompass
 version: ${version}
 description: Find biomes anywhere in any dimension!
 author: rusthero
-website: https://github.com/rusthero/BiomeCompass
+website: https://www.spigotmc.org/resources/biome-compass.106779/
 
 api-version: 1.16
 main: dev.rusthero.biomecompass.BiomeCompass


### PR DESCRIPTION
This pull request adds two new features to the Biome Compass plugin: a distance indicator and a version tracker. The distance indicator displays the distance to the selected biome in the compass GUI, allowing players to more easily navigate to their destination. The version tracker checks the plugin's version against the latest release, and alerts the server owner if they are using an outdated version.

Additionally, this pull request includes an option in the configuration file to enable or disable specific biomes. This allows server administrators to customize the biomes available for selection in the compass GUI.