### PR TITLE
Release 1.2.0: Add configurable costs and custom texture options for Biome Compas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'dev.rusthero.biomecompass'
-version '1.1.0'
+version '1.2.0'
 
 compileJava.options.encoding = "UTF-8"
 

--- a/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
+++ b/src/main/java/dev/rusthero/biomecompass/BiomeCompass.java
@@ -95,11 +95,12 @@ public class BiomeCompass extends JavaPlugin {
         pluginManager.registerEvents(new MenuDragListener(biomesMenu), this);
         pluginManager.registerEvents(new PrepareCraftListener(), this);
 
-        // Prepare vault and economy for Biome Compass money cost.
-        if (settings.moneyCost > 0 && pluginManager.getPlugin("Vault") != null) {
-            RegisteredServiceProvider<Economy> registration = servicesManager.getRegistration(Economy.class);
-            if (registration != null) economy = registration.getProvider();
-        }
+        // Prepare Vault and economy for Biome Compass money cost.
+        if (settings.moneyCost > 0)
+            if (pluginManager.getPlugin("Vault") != null) {
+                RegisteredServiceProvider<Economy> registration = servicesManager.getRegistration(Economy.class);
+                if (registration != null) economy = registration.getProvider();
+            } else getLogger().warning("Money cost is disabled because Vault plugin is missing");
 
         // Add a shaped recipe for the Biome Compass.
         NamespacedKey biomeCompassKey = new NamespacedKey(this, "biome_compass");

--- a/src/main/java/dev/rusthero/biomecompass/Settings.java
+++ b/src/main/java/dev/rusthero/biomecompass/Settings.java
@@ -52,14 +52,14 @@ public final class Settings {
     public final int experienceCost;
 
     /**
+     * The amount of money required to use the Biome Compass.
+     */
+    public final double moneyCost;
+
+    /**
      * Determines which biomes are displayed in the Biome Compass GUI.
      */
     public final HashMap<Biome, Boolean> biomes;
-
-    /**
-     * The amount of money required to use the Biome Compass.
-     */
-    public final int moneyCost;
 
     /**
      * Constructs a new Settings instance and reads in the setting values from the specified configuration file.
@@ -73,7 +73,7 @@ public final class Settings {
         this.cacheSize = config.getInt("cache_size");
         this.showDistance = config.getBoolean("show_distance");
         this.experienceCost = config.getInt("experience_cost");
-        this.moneyCost = config.getInt("money_cost");
+        this.moneyCost = config.getDouble("money_cost");
 
         biomes = new HashMap<>();
         ConfigurationSection section = config.getConfigurationSection("biomes");

--- a/src/main/java/dev/rusthero/biomecompass/Settings.java
+++ b/src/main/java/dev/rusthero/biomecompass/Settings.java
@@ -82,7 +82,8 @@ public final class Settings {
                 try {
                     biomes.put(Biome.valueOf(biomeStr.toUpperCase()), section.getBoolean(biomeStr));
                 } catch (IllegalArgumentException ignored) {
-
+                    // We can safely ignore if a biome name is invalid because we cannot locate a biome which does
+                    // not exist within this version anyway.
                 }
             });
     }

--- a/src/main/java/dev/rusthero/biomecompass/Settings.java
+++ b/src/main/java/dev/rusthero/biomecompass/Settings.java
@@ -41,6 +41,9 @@ public final class Settings {
      */
     public final int cacheSize;
 
+    /**
+     * Determines which biomes are displayed in the Biome Compass GUI.
+     */
     public final HashMap<Biome, Boolean> biomes;
 
     /**

--- a/src/main/java/dev/rusthero/biomecompass/Settings.java
+++ b/src/main/java/dev/rusthero/biomecompass/Settings.java
@@ -42,6 +42,11 @@ public final class Settings {
     public final int cacheSize;
 
     /**
+     * A flag indicating whether the distance to the target biome should be displayed when the compass is used.
+     */
+    public final boolean showDistance;
+
+    /**
      * Determines which biomes are displayed in the Biome Compass GUI.
      */
     public final HashMap<Biome, Boolean> biomes;
@@ -56,6 +61,7 @@ public final class Settings {
         this.resolution = config.getInt("resolution");
         this.radius = config.getInt("radius");
         this.cacheSize = config.getInt("cache_size");
+        this.showDistance = config.getBoolean("show_distance");
 
         biomes = new HashMap<>();
         ConfigurationSection section = config.getConfigurationSection("biomes");

--- a/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
+++ b/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
@@ -12,7 +12,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 
 /**
- * a utility class for the Biome Compass plugin that allows the plugin to check for updates from the plugin's GitHub
+ * An utility class for the Biome Compass plugin that allows the plugin to check for updates from the plugin's GitHub
  * repository.
  */
 public class VersionTracker {
@@ -37,7 +37,7 @@ public class VersionTracker {
     public final String currentVersion;
 
     /**
-     * latest version of the plugin, as retrieved from the GitHub API.
+     * Latest version of the plugin, as retrieved from the GitHub API.
      */
     public final String latestVersion;
 

--- a/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
+++ b/src/main/java/dev/rusthero/biomecompass/VersionTracker.java
@@ -11,26 +11,42 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+/**
+ * a utility class for the Biome Compass plugin that allows the plugin to check for updates from the plugin's GitHub
+ * repository.
+ */
 public class VersionTracker {
-    private static final URL API_URL;
+    /**
+     * URL of the GitHub API endpoint for the plugin's releases. This field is used to retrieve the latest version of
+     * the plugin when the {@link VersionTracker} object is constructed.
+     */
+    private static final URL ENDPOINT_URL;
 
     static {
         try {
-            API_URL = new URL("https://api.github.com/repos/rusthero/BiomeCompass/releases/latest");
+            ENDPOINT_URL = new URL("https://api.github.com/repos/rusthero/BiomeCompass/releases/latest");
         } catch (MalformedURLException exception) {
             // This should never throw.
             throw new RuntimeException(exception);
         }
     }
 
+    /**
+     * Current version of the plugin, as specified in the plugin's plugin.yml file.
+     */
     public final String currentVersion;
+
+    /**
+     * latest version of the plugin, as retrieved from the GitHub API.
+     */
     public final String latestVersion;
 
     public VersionTracker(BiomeCompass plugin) throws IOException {
         PluginDescriptionFile descriptionFile = plugin.getDescription();
+        // We use the prefix "v" in release tag names.
         currentVersion = "v" + descriptionFile.getVersion();
 
-        HttpURLConnection connection = (HttpURLConnection) API_URL.openConnection();
+        HttpURLConnection connection = (HttpURLConnection) ENDPOINT_URL.openConnection();
 
         BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream()));
         JsonElement json = new JsonParser().parse(reader);
@@ -38,6 +54,12 @@ public class VersionTracker {
         latestVersion = json.getAsJsonObject().get("tag_name").getAsString();
     }
 
+    /**
+     * Checks if the plugin is up-to-date.
+     *
+     * @return {@code true} if the current version of the plugin is the same as the latest version, and {@code false}
+     * otherwise.
+     */
     public boolean isUpToDate() {
         return currentVersion.equals(latestVersion);
     }

--- a/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
+++ b/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
@@ -71,7 +71,7 @@ public class ItemUseListener implements Listener {
             }
         // Check if player has sufficient funds and withdraw money and experience.
         final Economy economy = plugin.getEconomy();
-        final int moneyCost = plugin.getSettings().moneyCost;
+        final double moneyCost = plugin.getSettings().moneyCost;
         if (moneyCost > 0 && economy != null)
             if (!economy.has(player, moneyCost)) {
                 player.spigot().sendMessage(ACTION_BAR, new TextComponent("§cInsufficient funds"));

--- a/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
+++ b/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
@@ -61,29 +61,23 @@ public class ItemUseListener implements Listener {
             return;
         }
 
-        // Check if player has enough experience, do not withdraw before being sure player has the funds.
+        // Check if player has enough experience
         final int experienceCost = plugin.getSettings().experienceCost;
-        if (experienceCost > 0) {
-            final int playerExperience = Experience.getExp(player);
-            if (playerExperience < experienceCost) {
+        if (experienceCost > 0)
+            if (Experience.getExp(player) < experienceCost) {
                 player.spigot().sendMessage(ACTION_BAR, new TextComponent("§cInsufficient experience"));
                 player.playSound(location, BLOCK_CONDUIT_ATTACK_TARGET, 1.0f, 1.0f);
                 return;
             }
-        }
         // Check if player has sufficient funds and withdraw money and experience.
         final Economy economy = plugin.getEconomy();
         final int moneyCost = plugin.getSettings().moneyCost;
-        if (moneyCost > 0 && economy != null) {
+        if (moneyCost > 0 && economy != null)
             if (!economy.has(player, moneyCost)) {
                 player.spigot().sendMessage(ACTION_BAR, new TextComponent("§cInsufficient funds"));
                 player.playSound(location, BLOCK_CONDUIT_ATTACK_TARGET, 1.0f, 1.0f);
                 return;
             }
-            economy.withdrawPlayer(player, moneyCost);
-        }
-        // Withdraw experience here because we want to be sure player also has enough funds.
-        Experience.giveExp(player, -experienceCost);
 
         player.playSound(location, BLOCK_ENDER_CHEST_OPEN, 1.0f, 4.0f);
         plugin.getBiomesMenu().open(player);

--- a/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
+++ b/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
@@ -67,6 +67,7 @@ public class ItemUseListener implements Listener {
             final int playerExperience = Experience.getExp(player);
             if (playerExperience < experienceCost) {
                 player.spigot().sendMessage(ACTION_BAR, new TextComponent("§cInsufficient experience"));
+                player.playSound(location, BLOCK_CONDUIT_ATTACK_TARGET, 1.0f, 1.0f);
                 return;
             }
             Experience.giveExp(player, -experienceCost);
@@ -78,6 +79,7 @@ public class ItemUseListener implements Listener {
         if (moneyCost > 0 && economy != null) {
             if (!economy.has(player, moneyCost)) {
                 player.spigot().sendMessage(ACTION_BAR, new TextComponent("§cInsufficient funds"));
+                player.playSound(location, BLOCK_CONDUIT_ATTACK_TARGET, 1.0f, 1.0f);
                 return;
             }
             economy.withdrawPlayer(player, moneyCost);

--- a/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
+++ b/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
@@ -66,10 +66,10 @@ public class ItemUseListener implements Listener {
         if (experienceCost > 0) {
             final int playerExperience = Experience.getExp(player);
             if (playerExperience < experienceCost) {
-                player.spigot().sendMessage(ACTION_BAR, new TextComponent("Insufficient experience"));
+                player.spigot().sendMessage(ACTION_BAR, new TextComponent("§cInsufficient experience"));
                 return;
             }
-            Experience.changeExp(player, playerExperience - experienceCost);
+            Experience.giveExp(player, -experienceCost);
         }
 
         // Check if player has sufficient funds and withdraw.

--- a/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
+++ b/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
@@ -61,7 +61,7 @@ public class ItemUseListener implements Listener {
             return;
         }
 
-        // Check if player has enough experience, if so withdraw.
+        // Check if player has enough experience, do not withdraw before being sure player has the funds.
         final int experienceCost = plugin.getSettings().experienceCost;
         if (experienceCost > 0) {
             final int playerExperience = Experience.getExp(player);
@@ -70,10 +70,8 @@ public class ItemUseListener implements Listener {
                 player.playSound(location, BLOCK_CONDUIT_ATTACK_TARGET, 1.0f, 1.0f);
                 return;
             }
-            Experience.giveExp(player, -experienceCost);
         }
-
-        // Check if player has sufficient funds and withdraw.
+        // Check if player has sufficient funds and withdraw money and experience.
         final Economy economy = plugin.getEconomy();
         final int moneyCost = plugin.getSettings().moneyCost;
         if (moneyCost > 0 && economy != null) {
@@ -84,6 +82,8 @@ public class ItemUseListener implements Listener {
             }
             economy.withdrawPlayer(player, moneyCost);
         }
+        // Withdraw experience here because we want to be sure player also has enough funds.
+        Experience.giveExp(player, -experienceCost);
 
         player.playSound(location, BLOCK_ENDER_CHEST_OPEN, 1.0f, 4.0f);
         plugin.getBiomesMenu().open(player);

--- a/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
+++ b/src/main/java/dev/rusthero/biomecompass/listeners/ItemUseListener.java
@@ -56,7 +56,7 @@ public class ItemUseListener implements Listener {
             return;
         }
         if (locator.isOnCooldown()) {
-            player.spigot().sendMessage(ACTION_BAR, new TextComponent("§9Cooling Down"));
+            player.spigot().sendMessage(ACTION_BAR, new TextComponent("§9Cooling down"));
             player.playSound(location, BLOCK_CONDUIT_ATTACK_TARGET, 1.0f, 1.0f);
             return;
         }

--- a/src/main/java/dev/rusthero/biomecompass/listeners/MenuClickListener.java
+++ b/src/main/java/dev/rusthero/biomecompass/listeners/MenuClickListener.java
@@ -78,12 +78,12 @@ public class MenuClickListener implements Listener {
         }
         // Withdraw money from the player.
         final Economy economy = plugin.getEconomy();
-        final int moneyCost = plugin.getSettings().moneyCost;
+        final double moneyCost = plugin.getSettings().moneyCost;
         if (moneyCost > 0 && economy != null) {
             if (!economy.has(player, moneyCost)) return;
             economy.withdrawPlayer(player, moneyCost);
             String currencyName = moneyCost == 1 ? economy.currencyNameSingular() : economy.currencyNamePlural();
-            costMessages.add(format("§6%d %s", moneyCost, currencyName));
+            costMessages.add(format("§6%.2f %s", moneyCost, currencyName));
         }
         String locatingMessage = "§eLocating";
         if (costMessages.size() > 0) locatingMessage += ": §cCost: " + String.join("§c, ", costMessages);

--- a/src/main/java/dev/rusthero/biomecompass/listeners/MenuClickListener.java
+++ b/src/main/java/dev/rusthero/biomecompass/listeners/MenuClickListener.java
@@ -99,7 +99,7 @@ public class MenuClickListener implements Listener {
 
                 String locatedMessage = "§aLocated";
                 // If player teleports to another dimension while locating, we cannot calculate distance.
-                if (player.getWorld().equals(location.get().getWorld())) {
+                if (plugin.getSettings().showDistance && player.getWorld().equals(location.get().getWorld())) {
                     int distance = (int) Math.round(player.getLocation().distance(location.get()));
                     locatedMessage += format(" (§e%d blocks away§a)", distance);
                 }

--- a/src/main/java/dev/rusthero/biomecompass/util/Experience.java
+++ b/src/main/java/dev/rusthero/biomecompass/util/Experience.java
@@ -89,7 +89,7 @@ public final class Experience {
     }
 
     /**
-     * Change a Player's experience.
+     * Gives experience to a player.
      *
      * <p>This method is preferred over {@link Player#giveExp(int)}.
      * <br>In older versions the method does not take differences in exp per level into account.
@@ -101,7 +101,7 @@ public final class Experience {
      * @param player Player to be affected.
      * @param exp    The amount of experience to add or remove.
      */
-    public static void changeExp(Player player, int exp) {
+    public static void giveExp(Player player, int exp) {
         exp += getExp(player);
 
         if (exp < 0) exp = 0;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,7 +7,7 @@ radius: 6400
 cache_size: 100
 show_distance: true
 experience_cost: 64
-money_cost: 0
+money_cost: 0.0
 
 biomes:
   ocean: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,6 +5,7 @@ cooldown: 5
 resolution: 32
 radius: 6400
 cache_size: 100
+show_distance: true
 
 biomes:
   ocean: true

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: BiomeCompass
 version: ${version}
 description: Find biomes anywhere in any dimension!
 author: rusthero
-website: https://github.com/rusthero/BiomeCompass
+website: https://www.spigotmc.org/resources/biome-compass.106779/
 
 api-version: 1.16
 main: dev.rusthero.biomecompass.BiomeCompass


### PR DESCRIPTION
This pull request contains changes for the release of version 1.2.0 of the Biome Compass plugin. The following new features have been added:
  - Configurable experience cost and money cost (using Vault) for using the biome compass.
  - An option to disable the distance indicator from the configuration file.
  - Custom model data integer (10918) for adding custom texture to the biome compass item.